### PR TITLE
topo sort modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var path = require('path');
 var JSONStream = require('JSONStream');
 var combine = require('stream-combiner');
 var nub = require('nub');
-var toposort = require('toposort');
 var depsTopoSort = require('deps-topo-sort');
 var reverse = require('reversepoint');
 
@@ -94,15 +93,8 @@ Factor.prototype._transform = function (row, enc, next) {
 Factor.prototype._flush = function () {
     var self = this;
     
-    var deps = [];
-    Object.keys(self._buffered).forEach(function (file) {
-        Object.keys(self._buffered[file].deps).forEach(function (dep) {
-            deps.push([self._buffered[file].id, self._buffered[file].deps[dep]])
-        });
-    });
-    var order = toposort.array(Object.keys(self._buffered), deps);
     var ensureCommon = {};
-    order.forEach(function (file) {
+    Object.keys(self._buffered).forEach(function (file) {
         var row = self._buffered[file];
         
         var groups = nub(self._groups[file] || []);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "minimist": "~0.0.5",
     "stream-combiner": "~0.0.4",
     "nub": "0.0.0",
-    "toposort": "~0.2.10",
     "deps-topo-sort": "~0.2.0",
     "reversepoint": "~0.2.0"
   },


### PR DESCRIPTION
Topo Sort the modules before we starting factoring to ensure that we handle parents before we start handling dependencies.
