### PR TITLE
Support piping factored bundles to a stream.

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,8 @@ module.exports = function f (b, opts) {
 
         var s = createStream(files, opts);
         s.on('stream', function (bundle) {
-            var ws = fs.createWriteStream(fileMap[bundle.file]);
+            var output = fileMap[bundle.file];
+            var ws = isStream(output) ? output : fs.createWriteStream(output);
 
             bundle.pipe(pack(packOpts)).pipe(ws);
         });
@@ -187,3 +188,5 @@ Factor.prototype._makeStream = function (row) {
 Factor.prototype._resolveMap = function(id) {
     return this._rmap[id] || id;
 }
+
+function isStream (s) { return s && typeof s.pipe === 'function' }


### PR DESCRIPTION
If using factor-bundle as a Browserify plugin via the API, support
piping the factored bundles to a stream, in addition to the current
write-to-fs approach.

This allows factor-bundle to more easily utilized within streaming
environments.

``` javascript
var level = require('level');
var Store = require('level-store');
var browserify = require('browserify');
var factor = require('factor-bundle');

var store = Store(Level('/tmp/bundles'));

var b = browserify(['./entries/a.js', './entries/b.js']);
b.plugin(factor({
  o: [ store.createWriteStream('a'), store.createWriteStream('b') ]
}));
b.bundle().pipe(store.createWriteStream('common'));
```

While I'm not sure of the practicality of this example, it seemed like
a fun little thing to write.
