### PR TITLE
API enhancements

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var fs = require('fs');
 var pack = require('browser-pack');
 var xtend = require('xtend');
 var defined = require('defined');
+var splicer = require('labeled-stream-splicer');
 
 module.exports = function f (b, opts) {
     if (!opts) opts = {};
@@ -24,15 +25,20 @@ module.exports = function f (b, opts) {
 
     var needRecords = !files.length;
 
-    opts.outputs = opts.outputs || opts.o;
+    opts.outputs = defined(opts.outputs, opts.o, {});
     opts.objectMode = true;
     opts.raw = true;
     opts.rmap = {};
 
+    var packOpts = xtend(b._options, {
+        raw: true,
+        hasExports: true
+    });
+
     b.on('reset', addHooks);
     addHooks();
 
-    function addHooks() {
+    function addHooks () {
         b.pipeline.get('record').push(through.obj(function(row, enc, next) {
             if (needRecords) {
                 files.push(row.file);
@@ -40,24 +46,30 @@ module.exports = function f (b, opts) {
             next(null, row);
         }, function(next) {
             var cwd = defined(opts.basedir, b._options.basedir, process.cwd());
-            var fileMap = files.reduce(function (acc, x, ix) {
-                acc[path.resolve(cwd, x)] = opts.outputs[ix];
+            var pipelines = files.reduce(function (acc, x, ix) {
+                var pipeline = splicer.obj([
+                    'pack', [ pack(packOpts) ],
+                    'wrap', []
+                ]);
+                var output = opts.outputs[ix];
+                if (output) {
+                    var ws = isStream(output) ? output : fs.createWriteStream(output);
+                    pipeline.push(ws);
+                }
+                acc[path.resolve(cwd, x)] = pipeline;
                 return acc;
             }, {});
 
             // Force browser-pack to wrap the common bundle
             b._bpack.hasExports = true;
-            var packOpts = xtend(b._options, {
-                raw: true,
-                hasExports: true
+
+            Object.keys(pipelines).forEach(function (id) {
+                b.emit('factor.pipeline', id, pipelines[id]);
             });
 
             var s = createStream(files, opts);
             s.on('stream', function (bundle) {
-                var output = fileMap[bundle.file];
-                var ws = isStream(output) ? output : fs.createWriteStream(output);
-
-                bundle.pipe(pack(packOpts)).pipe(ws);
+                bundle.pipe(pipelines[bundle.file]);
             });
 
             b.pipeline.get('pack').unshift(s);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "defined": "0.0.0",
     "deps-topo-sort": "~0.2.1",
     "inherits": "^2.0.1",
+    "labeled-stream-splicer": "^1.0.0",
     "minimist": "~0.2.0",
     "nub": "0.0.0",
     "reversepoint": "~0.2.0",

--- a/readme.markdown
+++ b/readme.markdown
@@ -164,6 +164,17 @@ default).
 
 The entry file name is available as `stream.file`.
 
+## b.on('factor.pipeline', function (file, pipeline) {})
+
+Emits the full path to the entry file (`file`) and a [labeled-stream-splicer](https://npmjs.org/package/labeled-stream-splicer) (`pipeline`) for each entry file with these labels:
+
+* `'pack'` - [browser-pack](https://npmjs.org/package/browser-pack)
+* `'wrap'` - apply final wrapping
+
+You can call `pipeline.get` with a label name to get a handle on a stream pipeline that you can `push()`, `unshift()`, or `splice()` to insert your own transform streams.
+
+Event handlers must be attached *before* calling `b.plugin`.
+
 # install
 
 With [npm](https://npmjs.org) do:

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -72,12 +72,13 @@ test('browserify plugin multiple bundle calls', function(t) {
 
     var b = browserify(files);
     var sources = {};
-    b.plugin(factor, {
-        o: [
-            function() { return concat(function(data) { sources.x = data }); },
-            function() { return concat(function(data) { sources.y = data }); }
-        ]
+    b.on('factor.pipeline', function(id, pipeline) {
+        pipeline.pipe(concat(function(data) {
+            if (/x\.js$/.test(id)) sources.x = data;
+            else sources.y = data;
+        }));
     });
+    b.plugin(factor);
 
     b.bundle().pipe(concat(function(data) {
         checkBundle(data);


### PR DESCRIPTION
This improves the plugin API use case for factor-bundle.
- Re-hook into the pipeline on `reset` &mdash; necessary when calling `bundle()` multiple times, e.g., with the watchify API
- ~~Attach `factored` method to browserify instance &mdash; creates/returns a `through` stream through which all factored bundle streams will pass. _Definitely open to suggestions on suitability, naming, etc._~~
- Add `opts.outputs` alias for `opts.o` to mirror `opts.entries`
- In addition to strings & streams, accept functions that return strings/streams in `opts.o`. This is necessary to recreate streams for multiple `bundle()` calls. Works nicely with [lazypipe](https://npmjs.org/package/lazypipe).
- ~~Added documentation around plugin usage with browserify API. The example uses gulp, but I'd be happy to change that.~~
