### PR TITLE
Handle deduped rows

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,6 +147,9 @@ Factor.prototype._transform = function (row, enc, next) {
         Object.keys(row.deps).forEach(function(k) {
             self._ensureCommon[row.deps[k]] = true;
         });
+        if (row.dedupeIndex) {
+            self._ensureCommon[row.dedupeIndex] = true;
+        }
         self.push(row);
     }
     else {

--- a/test/dedupe.js
+++ b/test/dedupe.js
@@ -1,0 +1,67 @@
+var test = require('tape');
+var through = require('through');
+var factor = require('../');
+
+var ROWS = {
+    A: { id: 1, file: '/a.js', deps: { 'E': 5 } },
+    B: { id: 2, file: '/b.js', deps: { 'D': 4 } },
+    C: { id: 3, file: '/c.js', deps: { 'D': 4, 'X': 6 } },
+    D: { id: 4, file: '/d.js', deps: { 'X': 6 }, dedupeIndex: 5 },
+    E: { id: 5, file: '/e.js', deps: { 'X': 6 } },
+    X: { id: 6, file: '/x.js', deps: {} }
+};
+
+var rmap = {
+    1: '/a.js',
+    2: '/b.js',
+    3: '/c.js',
+    4: '/d.js',
+    5: '/e.js',
+    6: '/x.js'
+};
+
+var expected = {};
+expected.common = [ ROWS.D, ROWS.E, ROWS.X ].sort(cmp);
+expected['/a.js'] = [ ROWS.A ];
+expected['/b.js'] = [ ROWS.B ];
+expected['/c.js'] = [ ROWS.C ];
+
+test('ensure common if deduped to common dep', function (t) {
+    t.plan(4);
+
+    var files = [ '/a.js', '/b.js', '/c.js' ];
+    var fr = factor(files, { objectMode: true, raw: true, rmap: rmap });
+    fr.on('stream', function (bundle) {
+        bundle.pipe(rowsOf(function (rows) {
+            console.log('----- ' + bundle.file + ' ROWS -----');
+            console.log(rows.sort(cmp));
+            t.deepEqual(rows.sort(cmp), expected[bundle.file]);
+        }));
+    });
+
+    fr.pipe(rowsOf(function (rows) {
+        console.log('----- COMMON ROWS -----');
+        console.log(rows.sort(cmp));
+        t.deepEqual(rows.sort(cmp), expected.common);
+    }));
+
+    fr.write(ROWS.A);
+    fr.write(ROWS.B);
+    fr.write(ROWS.C);
+    fr.write(ROWS.D);
+    fr.write(ROWS.E);
+    fr.write(ROWS.X);
+    fr.end();
+});
+
+function rowsOf (cb) {
+    var rows = [];
+    return through(write, end);
+
+    function write (row) { rows.push(row) }
+    function end () { cb(rows) }
+}
+
+function cmp (a, b) {
+    return a.id < b.id ? -1 : 1;
+}


### PR DESCRIPTION
If a deduped row is factored into the common bundle, the target row should also become common.

This can cause an issue when the same dependency can be resolved to multiple paths, but only one of them becomes common.

A concrete example would be with using `assert` and `util` in your web project. The `assert` module is pinned to an outdated version of `util`, whereas browserify uses the latest `util`, resulting in `assert/util` and `util` being extracted to node_modules. Code that uses `assert` will transitively use the outdated version of `util`, which browserify can dedupe to its actual `util`. But if `assert/util` is used multiple times when `util` is only used once, a runtime error is thrown because the `assert/util` dependency on `util` is not available in the common script.

This fixes that :)
