### PR TITLE
Create implied dependency on dedupe target when sorting

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,18 +74,17 @@ function createStream (files, opts) {
     if (!opts) opts = {};
     
     var fr = new Factor(files, opts);
+    var sort = sortDeps();
     var parse, dup;
     
     if (opts.objectMode) {
-        dup = combine(depsTopoSort(), reverse(), fr);
+        dup = combine(sort, fr);
     }
     else {
         parse = JSONStream.parse([true]);
         dup = opts.raw
-            ? combine(parse, depsTopoSort(), reverse(), fr)
-            : combine(
-                parse, depsTopoSort(), reverse(), fr, JSONStream.stringify()
-            )
+            ? combine(parse, sort, fr)
+            : combine(parse, sort, fr, JSONStream.stringify())
         ;
         parse.on('error', function (err) { dup.emit('error', err) });
     }
@@ -191,6 +190,26 @@ Factor.prototype._makeStream = function (row) {
 
 Factor.prototype._resolveMap = function(id) {
     return this._rmap[id] || id;
-}
+};
 
 function isStream (s) { return s && typeof s.pipe === 'function' }
+
+function sortDeps () {
+    // create implied dependencies on dedupe targets for proper sorting
+    return combine(
+        through.obj(function(row, enc, next) {
+            if (row.dedupeIndex && row.dedupe) {
+                row.deps[row.dedupe] = row.dedupeIndex;
+            }
+            next(null, row);
+        }),
+        depsTopoSort(),
+        through.obj(function(row, enc, next) {
+            if (row.dedupeIndex && row.dedupe) {
+                delete row.deps[row.dedupe];
+            }
+            next(null, row);
+        }),
+        reverse()
+    );
+}

--- a/test/dedupe.js
+++ b/test/dedupe.js
@@ -3,11 +3,11 @@ var through = require('through');
 var factor = require('../');
 
 var ROWS = {
-    A: { id: 1, file: '/a.js', deps: { 'E': 5 } },
-    B: { id: 2, file: '/b.js', deps: { 'D': 4 } },
-    C: { id: 3, file: '/c.js', deps: { 'D': 4, 'X': 6 } },
-    D: { id: 4, file: '/d.js', deps: { 'X': 6 }, dedupeIndex: 5 },
-    E: { id: 5, file: '/e.js', deps: { 'X': 6 } },
+    A: { id: 1, file: '/a.js', deps: { '/e.js': 5 } },
+    B: { id: 2, file: '/b.js', deps: { '/e.js': 5 } },
+    C: { id: 3, file: '/c.js', deps: { '/d.js': 4, '/x.js': 6 } },
+    D: { id: 4, file: '/d.js', deps: { '/x.js': 6 } },
+    E: { id: 5, file: '/e.js', deps: { '/x.js': 6 }, dedupeIndex: 4, dedupe: '/d.js' },
     X: { id: 6, file: '/x.js', deps: {} }
 };
 


### PR DESCRIPTION
As discussed in #38.

This ensures that dedupe targets will be processed _after_ dependencies that point to them.

I restructured the test case to fake this scenario and I'm open to suggestions on better ways to solve this. This solution has the advantage of working with the existing deps-topo-sort (and it cleans up after itself immediately), but it's kind of hacky.
